### PR TITLE
fix: soft disable mismatch indicator for sqljs driver

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -254,14 +254,6 @@ body {
   color: var(--color-text);
 }
 
-.libsql-mismatch-arrow {
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-width: 0 8px 8px 0;
-  border-color: transparent theme("colors.red.400") transparent transparent;
-}
-
 .dark .libsql-removed-row td {
   @apply bg-red-800;
 }

--- a/src/components/gui/table-cell/generic-cell.tsx
+++ b/src/components/gui/table-cell/generic-cell.tsx
@@ -12,10 +12,16 @@ import {
 import {
   DatabaseResultSet,
   DatabaseValue,
+  describeTableColumnType,
   TableColumnDataType,
 } from "@/drivers/base-driver";
 import { useDatabaseDriver } from "@/context/driver-provider";
 import { convertDatabaseValueToString } from "@/drivers/sqlite/sql-helper";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface TableCellProps<T = unknown> {
   align?: "left" | "right";
@@ -171,6 +177,7 @@ function BlobCellValue({
 
 export default function GenericCell({
   value,
+  valueType,
   onFocus,
   isChanged,
   focus,
@@ -269,18 +276,10 @@ export default function GenericCell({
 
   return (
     <div className="relative">
-      {/*
-        Temporary disable mismatch hint:
-        - Some driver do not support BigInteger which gives a false positive warning
-          (This can easily be fixed)
-        - Some driver do not even give us the header type
-          (For sqljs driver does not return header type. I need to find better driver first)
-        
-      */}
-      {/* {valueType && header.dataType && valueType !== header.dataType && (
+      {valueType && header.dataType && valueType !== header.dataType && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="libsql-mismatch-arrow absolute right-0 top-0"></div>
+            <div className="w-0 h-0 border-transparent border-r-8 border-b-8 border-r-red-400 dark:border-r-red-600 absolute right-0 top-0"></div>
           </TooltipTrigger>
           <TooltipContent>
             <strong>Mismatched type:</strong>
@@ -296,7 +295,7 @@ export default function GenericCell({
             </ul>
           </TooltipContent>
         </Tooltip>
-      )} */}
+      )}
 
       <div
         className={className}

--- a/src/components/gui/tabs/query-tab.tsx
+++ b/src/components/gui/tabs/query-tab.tsx
@@ -117,8 +117,8 @@ export default function QueryWindow({
       setProgress(undefined);
       setQueryTabIndex(0);
 
-      multipleQuery(databaseDriver, finalStatements, (currentProgrss) => {
-        setProgress(currentProgrss);
+      multipleQuery(databaseDriver, finalStatements, (currentProgress) => {
+        setProgress(currentProgress);
       })
         .then(({ result: completeQueryResult, logs: completeLogs }) => {
           setData(completeQueryResult);

--- a/src/drivers/sqljs-driver.ts
+++ b/src/drivers/sqljs-driver.ts
@@ -56,8 +56,8 @@ export default class SqljsDriver extends SqliteLikeBaseDriver {
       return {
         name: renameColName,
         displayName: colName,
-        originalType: "text",
-        type: TableColumnDataType.TEXT,
+        originalType: null,
+        type: undefined,
       };
     });
 


### PR DESCRIPTION
Since this driver does not report the column type, the type should be treated as `undefined`, which causes the type analysis system to be disabled for this driver.

---

Since you mentioned that you’re implementing MySQL support, it’s not necessary to approve this PR right now. When you're ready, let me know, and I’ll do a rebase and adjust whatever is needed.

As for this PR, in short, I just removed the internal indication that forced the `TEXT` type for all columns when using `sqljs` to be undefined. This way, the mismatch indicator system will be disabled.

I also migrated the code I had created in `global.css` to pure Tailwind, which I believe is ideal. I also fixed a typo.






