### PR TITLE
feat: added ellipsis for large numbers, texts, and links

### DIFF
--- a/src/components/gui/table-cell/display-link-cell.tsx
+++ b/src/components/gui/table-cell/display-link-cell.tsx
@@ -12,11 +12,11 @@ export default function DisplayLinkCell({ link }: { link: string }) {
   const isImage = IMAGE_EXTENSION.includes((extension ?? "").toLowerCase());
 
   return (
-    <div className="flex">
+    <div className="flex w-full">
       <HoverCard>
         <HoverCardTrigger
           target="_blank"
-          className="text-blue-600 dark:text-blue-300 underline"
+          className="text-blue-600 dark:text-blue-300 underline flex-1 text-ellipsis overflow-hidden whitespace-nowrap"
         >
           {link}
         </HoverCardTrigger>

--- a/src/components/gui/table-cell/generic-cell.tsx
+++ b/src/components/gui/table-cell/generic-cell.tsx
@@ -225,9 +225,10 @@ export default function GenericCell({
 
       return (
         <span
-          className={
+          className={cn(
+            "flex-1 text-ellipsis overflow-hidden whitespace-nowrap",
             isChanged ? "text-black" : "text-green-600 dark:text-green-500"
-          }
+          )}
         >
           {value}
         </span>
@@ -237,11 +238,12 @@ export default function GenericCell({
     if (typeof value === "number" || typeof value === "bigint") {
       return (
         <span
-          className={
+          className={cn(
+            "flex-1 text-ellipsis overflow-hidden whitespace-nowrap",
             isChanged
               ? "text-black block text-right flex-grow"
               : "text-blue-700 dark:text-blue-300 block text-right flex-grow"
-          }
+          )}
         >
           {value.toString()}
         </span>
@@ -275,7 +277,7 @@ export default function GenericCell({
           (This can easily be fixed)
         - Some driver do not even give us the header type
           (For sqljs driver does not return header type. I need to find better driver first)
-        
+
       */}
       {/* {valueType && header.dataType && valueType !== header.dataType && (
         <Tooltip>


### PR DESCRIPTION
This feature had already been added to BLOBs; now it has been extended to other supported types as well, in case the content doesn’t fit within the box.

**Before:**

![image](https://github.com/user-attachments/assets/d8ce2cfc-85e6-4cae-a5aa-0b4b59156112)

**After:**

![image](https://github.com/user-attachments/assets/67e4054d-f9f5-413c-9f2b-2478f2f06695)
